### PR TITLE
base.py: Fix FAIL creation in execute()

### DIFF
--- a/base.py
+++ b/base.py
@@ -107,7 +107,7 @@ class Util:
         if show_cmd:
             Util.cmd(orig_cmd)
 
-        fail_file = Util.format_slash(ScriptRepo.IGNORE_FAIL_FILE)
+        fail_file = Util.format_slash('%s-%s' % (ScriptRepo.IGNORE_FAIL_FILE, Util.get_datetime()))
         if not dryrun:
             Util.ensure_file(fail_file)
             if Util.HOST_OS == Util.WINDOWS:
@@ -259,10 +259,8 @@ class Util:
 
     @staticmethod
     def ensure_nofile(file_path):
-        if not os.path.exists(file_path):
-            return
-
-        os.remove(file_path)
+        if os.path.exists(file_path):
+            os.remove(file_path)
 
     @staticmethod
     def ensure_symlink(src, dst):


### PR DESCRIPTION
The execute() return fail if the file named FAIL exists and always
remove the FAIL at the end. If there are two dependent execute(A)
and execute(B), B's fail does not make A fail as expected because
the FAIL had been removed by B.

Add datetime to create different fail files for each command
execution.