### PR TITLE
base.py: Fix fail file name in execute()

### DIFF
--- a/base.py
+++ b/base.py
@@ -19,7 +19,7 @@ import os
 from os.path import expanduser
 import pickle
 import platform
-import random
+import uuid
 import re
 import select
 import shutil
@@ -107,7 +107,7 @@ class Util:
         if show_cmd:
             Util.cmd(orig_cmd)
 
-        fail_file = Util.format_slash('%s-%s' % (ScriptRepo.IGNORE_FAIL_FILE, Util.get_datetime()))
+        fail_file = Util.format_slash('%s-%s' % (ScriptRepo.IGNORE_FAIL_FILE, uuid.uuid4()))
         if not dryrun:
             Util.ensure_file(fail_file)
             if Util.HOST_OS == Util.WINDOWS:

--- a/base.py
+++ b/base.py
@@ -19,7 +19,7 @@ import os
 from os.path import expanduser
 import pickle
 import platform
-import uuid
+import random
 import re
 import select
 import shutil
@@ -29,6 +29,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 import zipfile
 
 try:


### PR DESCRIPTION
The fail file is named based on local time, if execute() is called two times in one second, they will create the fail file with same name, and the second execute will delete the fail file of the first one, which causes the first execute cannot return correct value.

Use uuid instead of time for the fail file name.