### PR TITLE
base.py: Remove update_gpu_test_expectations

### DIFF
--- a/base.py
+++ b/base.py
@@ -1016,63 +1016,6 @@ class Util:
         return [sys.version_info.major, sys.version_info.minor, sys.version_info.micro]
 
     @staticmethod
-    def update_gpu_test_expectations(expectation_file):
-        if not os.path.exists(expectation_file):
-            Util.warning(f'{expectation_file} does not exist')
-            return
-
-        # Match intel tag in the gpu tags, such as '[ webgpu-adapter-default intel ]',
-        # '[ intel-gen-9 win10 ]' and '[ intel-0x9bc5 ]'.
-        intel_tag_pattern = re.compile(r'intel\S*')
-
-        # Hold the lines with the 'intel' tag for duplication check.
-        # Because there may be some expectations with same case, but different device ids,
-        # after the update, there will be duplicate record, which is not allowed.
-        intel_lines = []
-
-        tag_header_scope = True
-        update_comment = f'# LOCAL UPDATE FOR INTEL GPUS'
-        has_update_comment = False
-        for line in fileinput.input(expectation_file, inplace=True):
-            # Skip if the expectation file has been updated.
-            if has_update_comment:
-                sys.stdout.write(line)
-                continue
-
-            if tag_header_scope:
-                if re.search(update_comment, line):
-                    has_update_comment = True
-                elif re.search('BEGIN TAG HEADER', line):
-                    line = f'{update_comment}\n' + line
-                elif re.search('END TAG HEADER', line):
-                    tag_header_scope = False
-            else:
-                if not line.startswith('#'):
-                    # Get first matching tags, which may be gpu tags or may not.
-                    gpu_tags = ''
-                    gpu_tags_match = re.search(r'\[.*?\]', line)
-                    if gpu_tags_match:
-                        gpu_tags = gpu_tags_match.group()
-
-                    if intel_tag_pattern.search(gpu_tags):
-                        # Replace 'intel*' with 'intel' in the gpu tags
-                        updated_gpu_tags = intel_tag_pattern.sub('intel', gpu_tags)
-
-                        updated_line = line if updated_gpu_tags == gpu_tags else line.replace(gpu_tags, updated_gpu_tags)
-
-                        # If the updated line already exists, just comment the line,
-                        # otherwise comment the line and append the updated line.
-                        # For the line already with 'intel' tag, keep as is if there is no duplicate line.
-                        if updated_line in intel_lines:
-                            line = "# " + line
-                        else:
-                            if updated_gpu_tags != gpu_tags:
-                                line =  "# " + line + updated_line
-                            intel_lines.append(updated_line)
-            sys.stdout.write(line)
-        fileinput.close()
-
-    @staticmethod
     def get_test_result(result_file, type):
         def _is_pass(val):
             return str(val).endswith('PASS')


### PR DESCRIPTION
The update_gpu_test_expectations was moved to toolkit to avoid updating both util and toolkit every time. See [toolkit#34](https://github.com/webatintel/toolkit/pull/34).